### PR TITLE
experiment: replace powers list with range() using jupyter notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 dist/
 *.egg-info/
 .pytest_cache/
+.ipynb_checkpoints/

--- a/shortscale.ipynb
+++ b/shortscale.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 8_740_991_777_123\n",
+    "max_exponent = math.ceil(len(str(n)) / 3) - 1\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8 4 4\n",
+      "740 3 4\n",
+      "991 2 4\n",
+      "777 1 4\n",
+      "123 0 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "for x in range(max_exponent,-1,-1):\n",
+    "  p = 1000 ** x\n",
+    "  print((n // p), x, max_exponent)\n",
+    "  n = n % p\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: logarithms use floating point which doesn't scale => can't replace len(str(n)) with log10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16\n",
+      "15.0\n",
+      "15.999999999999996\n"
+     ]
+    }
+   ],
+   "source": [
+    "n1 = 1_000_000_000_000_000\n",
+    "n2 = 9_999_999_999_999_899  \n",
+    "print(len(str(n1)))\n",
+    "print(math.log10(n1))\n",
+    "print(math.log10(n2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "eec51541266663fd1332d435678e87baaaf52a71bcb3308b655b2ac7f20f0f27"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/shortscale.py
+++ b/shortscale.py
@@ -1,5 +1,6 @@
 """English conversion from number to string"""
 import sys
+import math
 
 __version__ = '1.1.1'
 
@@ -16,35 +17,24 @@ def shortscale(num: int) -> str:
     elif num >= 1000 ** 11:
         words += ' (big number)'
     else:
-        p_list = powers_of_1000(num)
-        exponent_count = len(p_list)
-        for (n, exponent) in p_list:
-            words += scale_words(n, exponent, exponent_count)
+        max_exponent = math.ceil(len(str(num)) / 3) - 1
+        for exponent in range(max_exponent,-1,-1):
+            power = 1000 ** exponent
+            n = num // power
+            words += scale_words(n, exponent, max_exponent)
+            num = num % power
 
     # return words string without leading space
     return words[1:]
 
-def powers_of_1000(n: int):
+def scale_words(n: int, exponent: int, max_exponent):
     """
-    Return list of (n, exponent) for each power of 1000.
-    List is ordered highest exponent first.
-    n = 0 - 999.
-    exponent = 0,1,2,3...
-    """
-    p_list = []
-    exponent = 0
-    while n > 0:
-        p_list.insert(0, (n % 1000, exponent))
-        n = n // 1000
-        exponent += 1
-
-    return p_list
-
-
-def scale_words(n: int, exponent: int, exponent_count):
-    """
-    return words for (n, exponent).
-    Highest exponent first, n = 0 - 999.
+    Return words for (n, exponent)
+    E.g.
+    (102,3) => ' one hundred and two billion'
+     (45,2) => ' forty five million'
+     (12,0) => ' and twelve' 
+            or ' twelve' (when max_exponent == 0)
     """
     s_words = ''
     if n == 0:
@@ -56,7 +46,7 @@ def scale_words(n: int, exponent: int, exponent_count):
 
     if tens_and_units := n % 100:
 
-        if hundreds or (exponent == 0 and exponent_count > 1):
+        if hundreds or (exponent == 0 and max_exponent > 0):
             s_words += ' and'
 
         if tens_and_units <= 20:

--- a/tests/bench_shortscale.py
+++ b/tests/bench_shortscale.py
@@ -12,8 +12,8 @@ def run():
   store.append(shortscale.shortscale(NUM))
 
 def report(calls:int, time:float):
-  print(f'{calls:10d} calls, {len(store[-1])*len(store):10d} bytes, {time * 1_000_000_000 / calls:>8.0f} ns/call')
+  print(f'{calls:10d} calls, {calls * 100:10d} bytes, {time * 1_000_000_000 / calls:>8.0f} ns/call')
 
-t = timeit.Timer('run()', 'setup()', globals=globals())
+t = timeit.Timer('shortscale.shortscale(NUM)', 'pass', globals=globals())
 
 t.autorange(report)

--- a/tests/test_shortscale.py
+++ b/tests/test_shortscale.py
@@ -53,6 +53,7 @@ TESTS = [
     (100_999_120, "one hundred million nine hundred and ninety nine thousand one hundred and twenty"),
     (999_999_120, "nine hundred and ninety nine million nine hundred and ninety nine thousand one hundred and twenty"),
     (420_000_999_015, "four hundred and twenty billion nine hundred and ninety nine thousand and fifteen"),
+    (50_000_050_000_050, "fifty trillion fifty million and fifty"),
     (9_007_199_254_740_999, "nine quadrillion seven trillion one hundred and ninety nine billion two hundred and fifty four million seven hundred and forty thousand nine hundred and ninety nine"),
     (999_999_999_999_999_999, "nine hundred and ninety nine quadrillion nine hundred and ninety nine trillion nine hundred and ninety nine billion nine hundred and ninety nine million nine hundred and ninety nine thousand nine hundred and ninety nine"),
     (777_777_777_777_777_777, "seven hundred and seventy seven quadrillion seven hundred and seventy seven trillion seven hundred and seventy seven billion seven hundred and seventy seven million seven hundred and seventy seven thousand seven hundred and seventy seven"),


### PR DESCRIPTION
On local M1 laptop this implementation is slower

#### before
```
     50000 calls,    5000000 bytes,     2067 ns/call
    100000 calls,   10000000 bytes,     2072 ns/call
```

#### after
```
     50000 calls,    5000000 bytes,     2354 ns/call
    100000 calls,   10000000 bytes,     2342 ns/call
```